### PR TITLE
fix(ENG-11425): publish CocoaPods before changelog write-back

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,16 +80,19 @@ jobs:
 
           git commit -m "chore(release): upating podspec and changelog ${NEW_TAG} [skip ci]" || echo "Nothing to update"
 
+      # Publish to CocoaPods BEFORE pushing the changelog write-back to master, so
+      # a publish failure leaves master untouched and the release stays re-runnable.
+      # pod trunk push reads the local podspec, already version-bumped in Commit files.
+      - name: Push CocoaPods
+        run: pod trunk push --allow-warnings
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+
       - name: Push changes
         uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           branch: ${{ github.ref }}
-
-      - name: Push CocoaPods
-        run: pod trunk push --allow-warnings
-        env:
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
 
       - name: Stop Deploy Message
         if: always()


### PR DESCRIPTION
## Description
- Reorder the release job so `pod trunk push` runs **before** the changelog write-back push to master (`Commit files` bumps the local podspec → `Push CocoaPods` → `Push changes`).
- Previously the write-back push landed first, so a CocoaPods publish failure left master version-bumped and the job un-re-runnable (re-runs hit a non-fast-forward rejection). Publishing first keeps master untouched until the pod push succeeds, so failures are re-runnable. `pod trunk push` reads the local (already version-bumped) podspec, so it does not need the write-back pushed first.
- Merging this `fix:` also re-validates end-to-end (cuts the next patch tag, publishes the pod with the refreshed CocoaPods trunk token, then writes the changelog back via the app token).

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
[Link to docs if applicable, or leave empty]

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change