### PR TITLE
fix(ENG-11425): treat already-published CocoaPods version as success

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,28 @@ jobs:
       # a publish failure leaves master untouched and the release stays re-runnable.
       # pod trunk push reads the local podspec, already version-bumped in Commit files.
       - name: Push CocoaPods
-        run: pod trunk push --allow-warnings
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+          NEW_TAG: ${{ needs.cut-tag.outputs.new_tag }}
+        run: |
+          set +e
+          push_output=$(pod trunk push --allow-warnings 2>&1)
+          push_code=$?
+          printf '%s\n' "$push_output"
+          if [ "$push_code" -eq 0 ]; then
+            exit 0
+          fi
+          # Trunk sometimes accepts the spec but the trailing GitHub commit API call
+          # times out (pod exits non-zero), and re-runs then hit a duplicate entry.
+          # If the version is already on trunk, treat the push as successful so the
+          # changelog write-back still runs.
+          echo "pod trunk push exited ${push_code}; checking whether ${NEW_TAG} is already on trunk..."
+          if curl -sf "https://trunk.cocoapods.org/api/v1/pods/BasisTheoryElements" \
+               | grep -qE "\"name\"[[:space:]]*:[[:space:]]*\"${NEW_TAG}\""; then
+            echo "Version ${NEW_TAG} is already published to CocoaPods trunk; treating as success."
+            exit 0
+          fi
+          exit "${push_code}"
 
       - name: Push changes
         uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master


### PR DESCRIPTION
## Description
- Make the `Push CocoaPods` step idempotent. `pod trunk push` sometimes returns a non-zero exit even though the spec was accepted — e.g. trunk accepts the version but the trailing GitHub commit API call times out (`Calling the GitHub commit API timed out`), and a subsequent re-run then hits `Unable to accept duplicate entry`. In both cases the version is actually published.
- After a non-zero `pod trunk push`, check whether the version is already on CocoaPods trunk (`trunk.cocoapods.org/api/v1/pods/BasisTheoryElements`); if so, treat the push as successful so the changelog write-back (`Push changes`) still runs and master stays in sync.
- Motivation: during ENG-11425 release validation, `5.2.2` published successfully but a transient GitHub-API timeout made the step exit non-zero, so the write-back was skipped and master's podspec fell behind the published pod. This guard prevents that class of transient failure from breaking releases.
- On merge this also reconciles master: it cuts the next patch tag, publishes it, and completes the write-back.

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
[Link to docs if applicable, or leave empty]

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change